### PR TITLE
refresh cache to show new translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -616,7 +616,11 @@ You can workaround it manually by running
 ```bash
 $ rake assets:clobber
 ```
-to clear the asset cache.  
+to clear the asset cache.
+**Or**
+```bash
+$ rake tmp:cache:clear
+```
 **Or**  
 Change something in existing locale file.  
 **Or**  


### PR DESCRIPTION
Regarding https://github.com/fnando/i18n-js/issues/213, running 

``` bash
$ rake tmp:cache:clear
```

was the only thing that got my translation edits to apply. I'm running Rails 3, so I don't have

``` bash
$ rake assets:clobber
```
